### PR TITLE
London Underground status on a Blinky Tape

### DIFF
--- a/Huxley_UK_Rail_Station_Delays.py
+++ b/Huxley_UK_Rail_Station_Delays.py
@@ -26,8 +26,9 @@ import tempfile
 accessToken = "DA1C7740-9DA0-11E4-80E6-A920340000B1"
 
 # CRS codes here: http://www.nationalrail.co.uk/static/documents/content/station_codes.csv
-crs = "clj"       # Clapham Junction
-filterCrs = "wat" # to Waterloo
+crs = "clj"        # Clapham Junction
+filterCrs = "wat"  # to Waterloo
+trainTime = "0825" # STD of a specific train to look for (24hr format HHmm) blank for none
 
 
 # Default Blinky Tape port on Raspberry Pi is /dev/ttyACM0
@@ -43,7 +44,7 @@ else:
     print "(ex.: python huxley.py -p /dev/ttyACM0)"
     exit()
 
-url = "https://huxley.apphb.com/delays/{}/to/{}/50?accessToken={}".format(crs, filterCrs, accessToken)
+url = "https://huxley.apphb.com/delays/{}/to/{}/50/{}?accessToken={}".format(crs, filterCrs, trainTime, accessToken)
 
 bt = BlinkyTape(port)
 

--- a/Huxley_UK_Rail_Station_Delays.py
+++ b/Huxley_UK_Rail_Station_Delays.py
@@ -8,13 +8,14 @@ If there are delays between the configured stations then the Blinky Tape will th
 
 To run on default (Raspberry Pi) USB serial port: python Huxley_UK_Rail_Station_Delays.py &
 
-(C) 2015 James Singleton
+(C) 2015 James Singleton (https://unop.uk)
 MIT Licensed
 
 """
 
 from BlinkyTape import BlinkyTape
 from time import sleep
+from itertools import chain
 import optparse
 import urllib
 import json
@@ -28,7 +29,7 @@ accessToken = "DA1C7740-9DA0-11E4-80E6-A920340000B1"
 # CRS codes here: http://www.nationalrail.co.uk/static/documents/content/station_codes.csv
 crs = "clj"        # Clapham Junction
 filterCrs = "wat"  # to Waterloo
-trainTime = "0825" # STD of a specific train to look for (24hr format HHmm) blank for none
+trainTime = ""     # STD of a specific train to look for (24hr format HHmm) blank for none
 
 
 # Default Blinky Tape port on Raspberry Pi is /dev/ttyACM0
@@ -40,8 +41,8 @@ parser.add_option("-p", "--port", dest="portname",
 if options.portname is not None:
     port = options.portname
 else:
-    print "Usage: python huxley.py -p <port name>"
-    print "(ex.: python huxley.py -p /dev/ttyACM0)"
+    print "Usage: python Huxley_UK_Rail_Station_Delays.py -p <port name>"
+    print "(ex.: python Huxley_UK_Rail_Station_Delays.py -p /dev/ttyACM0)"
     exit()
 
 url = "https://huxley.apphb.com/delays/{}/to/{}/50/{}?accessToken={}".format(crs, filterCrs, trainTime, accessToken)
@@ -68,12 +69,9 @@ while True:
         stationStatus["locationName"], stationStatus["filterLocationName"], stationStatus["delays"])
 
         # Throb red for delays (or black for none) - takes at least 2 min
-        for xx in range(0,60):
-            for xy in xrange(0, 100):
-                bt.displayColor(xy * alert, 0, 0)
-                sleep(0.01)
-            for yx in xrange(100, 0, -1):
-                bt.displayColor(yx * alert, 0, 0)
+        for x in xrange(60):
+            for y in chain(xrange(100), xrange(100, 0, -1)):
+                bt.displayColor(y * alert, 0, 0)
                 sleep(0.01)
 
     except:

--- a/London_Underground_Status.py
+++ b/London_Underground_Status.py
@@ -1,0 +1,94 @@
+"""
+London Underground Status for Blinky Tape
+
+To run on default (Raspberry Pi) USB serial port: python London_Underground_Status.py &
+
+(C) 2015 James Singleton (https://unop.uk)
+MIT Licensed
+
+"""
+
+from BlinkyTape import BlinkyTape
+from time import sleep
+import optparse
+import urllib
+import json
+import tempfile
+
+# Default Blinky Tape port on Raspberry Pi is /dev/ttyACM0
+parser = optparse.OptionParser()
+parser.add_option("-p", "--port", dest="portname",
+                  help="serial port (ex: /dev/ttyACM0)", default="/dev/ttyACM0")
+(options, args) = parser.parse_args()
+
+if options.portname is not None:
+    port = options.portname
+else:
+    print "Usage: python London_Underground_Status.py -p <port name>"
+    print "(ex.: python London_Underground_Status.py -p /dev/ttyACM0)"
+    exit()
+
+url = "https://api.tfl.gov.uk/line/mode/tube,overground,dlr/status"
+
+colours = { "bakerloo" : (137, 78, 36),
+            "central" : (220, 36, 31),
+            "circle" : (255, 206, 0),
+            "district" : (0, 114, 41),
+            "dlr" : (0, 175, 173),
+            "hammersmith-city" : (215, 153, 175),
+            "jubilee" : (106, 114, 120), 
+            "london-overground" : (232, 106, 16),
+            "metropolitan" : (117, 16, 86),
+            "northern" : (0, 0, 0),
+            "piccadilly" : (0, 25, 168),
+            "victoria" : (0, 160, 226),
+            "waterloo-city" : (118, 208, 189) }
+
+bt = BlinkyTape(port)
+
+# Some visual indication that it works for headless setups (green tape)
+bt.displayColor(0, 100, 0)
+sleep(2)
+# Tape resets to stored pattern after a couple of seconds of inactivity
+
+while True:
+    try:
+        print "GET %s" % (url)
+        rawHttpResponse = urllib.urlopen(url)
+        lines = json.load(rawHttpResponse)
+
+        if not len(lines) or lines is None:
+            raise Exception("Error parsing data")
+
+        # Takes at least 2 min
+        for cycles in xrange(120):
+            for pixel in xrange(4):
+                bt.sendPixel(0, 0, 0)
+            for line in lines:
+                alert = False
+                for status in line['lineStatuses']:
+                    # https://api.tfl.gov.uk/line/meta/severity
+                    if status['statusSeverity'] != 10:
+                        alert = True
+                r, g, b = colours[line['id']]
+                for pixel in xrange(4):
+                    if alert:
+                        # Flash for delays
+                        l = (cycles - pixel) % 2
+                        if line['id'] == "northern":
+                            # Because black on black doesn't show up
+                            r, g, b = 100, 100, 100
+                        bt.sendPixel(l * r, l * g, l * b)
+                    else:
+                        bt.sendPixel(r, g, b)
+            for pixel in xrange(4):        
+                bt.sendPixel(0, 0, 0)
+            bt.show()
+            sleep(0.5)
+
+    except:
+        # Blue indicates an error
+        bt.displayColor(0, 0, 100)
+        sleep(120) # wait 2 min
+        pass
+


### PR DESCRIPTION
Added a script to display the [live London Underground status](https://www.tfl.gov.uk/tube-dlr-overground/status/) on the tape. 4 LEDs for each of the 13 lines with the correct colours. The respective segment will flash if there are service disruptions.

Also tweaked the mainline trains script to reduce code reuse and add support for a specific train.