### PR TITLE
Add write timeout

### DIFF
--- a/blinkytape.py
+++ b/blinkytape.py
@@ -51,7 +51,7 @@ class BlinkyTape(object):
         self.position = 0
         self.buffered = buffered
         self.buf = ""
-        self.serial = serial.Serial(port, 115200)
+        self.serial = serial.Serial(port, 115200, write_timeout=1)
         self.show()  # Flush any incomplete data
 
     def send_list(self, colors):


### PR DESCRIPTION
Adds a 1 second timeout to writes (should be plenty of time) to prevent the entire program from hanging if the blinkytape gets into a bad state and doesn't accept writes.

If this naive timeout isn't agreeable, perhaps add the timeout as a parameter to the blinkytape constructor with a default parameter of 0. In any case, it might be nice to have a timeout option without directly accessing the inner `Serial` object to set it.